### PR TITLE
feat(grunt-conventional-changelog): introduces grunt-conventional-change...

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -41,6 +41,11 @@ module.exports = function (grunt) {
         },
         qunit: {
             all: ['tests/*.html']
+        },
+        changelog: {
+          options: {
+            dest: 'CHANGELOG.md'
+          }
         }
     });
 
@@ -49,6 +54,7 @@ module.exports = function (grunt) {
     grunt.loadNpmTasks('grunt-contrib-qunit');
     grunt.loadNpmTasks('grunt-contrib-jshint');
     grunt.loadNpmTasks('grunt-contrib-watch');
+    grunt.loadNpmTasks('grunt-conventional-changelog');
 
     grunt.registerTask('nuget', 'Register NuGet-RxJS-Angular', function () {
         var done = this.async();

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     }
   ],
   "dependencies": {
-    "rx": "*"  
+    "rx": "*"
   },
   "devDependencies": {
     "grunt-cli": "*",
@@ -27,11 +27,12 @@
     "grunt-contrib-uglify": "*",
     "grunt-contrib-concat": "*",
     "grunt-contrib-qunit": "*",
-    "grunt-contrib-watch": "*"
+    "grunt-contrib-watch": "*",
+    "grunt-conventional-changelog": "~1.0.0"
   },
   "jam": {
     "main": "rx.angular.js"
-  },  
+  },
   "keywords": [
     "Reactive",
     "FRP",
@@ -43,5 +44,5 @@
   "main": "rx.angular.js",
   "scripts": {
     "test": "grunt"
-  }  
+  }
 }


### PR DESCRIPTION
...log plugin

this plugin let us auto generate changelogs for this project.
all you have to do is to provide proper commit messages that
follow a given convention (like this one).

the angular project itself uses conventional changelogs to
automate this process.
to generate a changelog simply run `grunt changelog:fromRef:toRef` and
specify a release tag from  which the changelog
should be generated.

Example output: https://github.com/btford/grunt-conventional-changelog/blob/master/CHANGELOG.md
Conventions: https://docs.google.com/document/d/1QrDFcIiPjSLDn3EL15IJygNPiHORgU1_OOAqWjiDU5Y/edit
