### PR TITLE
avoid ReferenceError Rx in failed build

### DIFF
--- a/src/intro.js
+++ b/src/intro.js
@@ -27,7 +27,9 @@
     }
 
     // Headers
-    var observable = Rx.Observable,
+    
+    var Rx = window.Rx,
+        observable = Rx.Observable,
         observableProto = observable.prototype,
         observableCreate = observable.create;
 


### PR DESCRIPTION
```
>> global failure
>> Message: ReferenceError: Can't find variable: Rx
>> file:///home/travis/build/Reactive-Extensions/rx.angular.js/rx.angular.js:32
```
