### PR TITLE
Made rx and observeOnScope factories minification-safe

### DIFF
--- a/src/factory.js
+++ b/src/factory.js
@@ -7,7 +7,7 @@
    * @description
    * Factory service that exposes the global `Rx` object to the Angular world.
    */
-  rxModule.factory('rx', function($window) {
+  rxModule.factory('rx', ["$window", function($window) {
     $window.Rx || ($window.Rx = Rx);
     return $window.Rx;
-  });
+  }]);

--- a/src/observeonscope.js
+++ b/src/observeonscope.js
@@ -15,7 +15,7 @@
 *
 * @return {function} Factory function that creates obersables.
 */
-  rxModule.factory('observeOnScope', function(rx) {
+  rxModule.factory('observeOnScope', ["rx", function(rx) {
     return function(scope, watchExpression, objectEquality) {
       return rx.Observable.create(function (observer) {
         // Create function to handle old and new Value
@@ -27,4 +27,4 @@
         return scope.$watch(watchExpression, listener, objectEquality);
       });
     };
-  });
+  }]);


### PR DESCRIPTION
The rx and observeOnScope factory registrations aren't done in a min-safe fashion and therefore break when minified.
