### PR TITLE
Add `manageScope` selector function

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -32,6 +32,7 @@ module.exports = function (grunt) {
           'src/$rootScopeExtensions.js',
           'src/observableRuntimeExtensions.js',
           'src/scopescheduler.js',
+          'src/manageScope.js',
           'src/outro.js'
         ],
         dest: 'dist/rx.angular.js'

--- a/src/manageScope.js
+++ b/src/manageScope.js
@@ -1,0 +1,30 @@
+  var manageScope = Rx.manageScope = function ($scope) {
+
+    return function(observer) {
+
+        var source = observer;
+
+        return new AnonymousObservable(function (observer) {
+
+            var m = new SingleAssignmentDisposable();
+
+            var scheduler = Rx.ScopeScheduler($scope);
+
+            m.setDisposable(source
+                .observeOn(scheduler)
+                .subscribe(
+                    observer.onNext.bind(observer),
+                    observer.onError.bind(observer),
+                    observer.onCompleted.bind(observer)
+            ));
+
+            $scope.$on("$destroy", function() {
+                m.dispose();
+                delete m;
+            });
+
+            return m;
+        });
+      }
+  }
+

--- a/tests/rx.angular.html
+++ b/tests/rx.angular.html
@@ -23,5 +23,6 @@
   <script src="tests.$rootScopeExtensions.js"></script>
   <script src="tests.safeApply.js"></script>
   <script src="tests.scopescheduler.js"></script>
+  <script src="tests.manageScope.js"></script>
 </body>
 </html>

--- a/tests/tests.manageScope.js
+++ b/tests/tests.manageScope.js
@@ -1,0 +1,39 @@
+module('manageScope');
+
+asyncTest('manages scope', function () {
+
+  var injector = angular.injector(['ng', 'rx']);
+
+  var scope = injector.get('$rootScope').$new();
+
+  var count = 0;
+
+  Rx.Observable.interval(1)
+    .let(Rx.manageScope(scope))
+    .subscribe(function(v) {
+      count += 1;
+      scope.value = v;
+    }
+  );
+
+  var total = 0;
+  setTimeout(function() {
+
+    scope.$destroy();
+    total = count;
+
+    setTimeout(function() {
+
+      start();
+
+      ok(
+        total === count,
+        "Expected " + total + " calls, but received " + count
+      );
+
+    }, 100);
+
+  }, 100);
+
+  expect(1);
+});


### PR DESCRIPTION
Allows any old observable sequence to be used in angular context. This
means that observables using this transform function are automatically
observing on the ScopeScheduler and are disposed upon
`$scope.$on("destroy")`.

This has the following advantages:

+ All code in `.subscribe` is happening in the right time of the digest
  cycle, i.e no flickering or missed updates
+ When the scope is destroyed, the observable is disposed off. This
  avoids subtle memory leaks where members of the scope managed by
  `ScopeScheduler` are still referenced past the scope's destruction.

This function is to be used in conjunction with with
`Rx.Observable.prototype.let`, consider:

```
Rx.Observable.interval(100)
  .let(Rx.manageScope($scope))
  .subscribe(...)
;
```