### PR TITLE
Export the module to be used with commonJS

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,1 +1,2 @@
 require('./dist/rx.angular');
+module.exports = 'rx';


### PR DESCRIPTION
Right now we can't use the module like other Angular modules.
This change follows the Angular core teams pattern.