### PR TITLE
change .editorconfig indent_size to match the existing code; fixes #81

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -2,7 +2,7 @@ root = true
 
 [*]
 indent_style = space
-indent_size = 4
+indent_size = 2
 end_of_line = lf
 charset = utf-8
 trim_trailing_whitespace = true


### PR DESCRIPTION
Now that I look more closely, *most* of the code is 2 spaces, but not all. The main RxJS project seems to be 2, FWIW. 

I just want to make sure I'm using the spacing desired by the maintainers, and it's unclear what that is.