### PR TITLE
stop bower ignoring .min.* files

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -9,7 +9,6 @@
     ".*",
     "*.bat",
     "*.md",
-    "*.min.*",
     "*.txt",
     "*.log",
     "package.json",


### PR DESCRIPTION
Allow 'bower install angular-rx' to pick up the file dist/rx.angular.min.js - it is currently ignored due to entry in bower.json