### PR TITLE
fix konami code example

### DIFF
--- a/examples/konamicode/app.js
+++ b/examples/konamicode/app.js
@@ -21,7 +21,7 @@
                         .selectMany(function (x) {
                             return x.sequenceEqual(konamiCode);
                         })
-                        .where(angular.noop)
+                        .where(angular.identity)
                         .subscribe(function () {
                             scope.$apply(scope.konamiCode);
                         });


### PR DESCRIPTION
Konami code example didn't work for me. Replacing` angular.noop` with `angular.identity` in the `where` operator fixes it.