### PR TITLE
change throttle() to debounce() to fix failing tests & Travis build

### DIFF
--- a/tests/tests.digest.js
+++ b/tests/tests.digest.js
@@ -7,7 +7,7 @@ asyncTest('assigns to simple scope properties', function () {
 
   scope
     .$toObservable('testProperty')
-    .throttle(500)
+    .debounce(500)
     .map(function(change) { return change.newValue + 1; })
     .digest(scope, 'testProperty2')
     .subscribe(function onNext(val) {
@@ -34,7 +34,7 @@ asyncTest('assigns to more complex assignable expressions', function () {
 
   scope
     .$toObservable('testProperty')
-    .throttle(500)
+    .debounce(500)
     .map(function(change) { return change.newValue + 1; })
     .digest(scope, 'ctrl.testProperty2')
     .subscribe(function onNext(val) {
@@ -61,7 +61,7 @@ asyncTest('sends an error if expression is not assignable', function () {
 
   scope
     .$toObservable('testProperty')
-    .throttle(500)
+    .debounce(500)
     .map(function(change) { return change.newValue + 1; })
     .digest(scope, 'testProperty2 === 5')
     .subscribe(function onNext() {

--- a/tests/tests.safeApply.js
+++ b/tests/tests.safeApply.js
@@ -11,7 +11,7 @@ asyncTest('calls $apply', function () {
 
   scope
     .$toObservable('testProperty')
-    .throttle(500)
+    .debounce(500)
     .safeApply(scope, function (val) {
       scope.testProperty = 2;
     })

--- a/tests/tests.scopescheduler.js
+++ b/tests/tests.scopescheduler.js
@@ -11,7 +11,7 @@ asyncTest('calls observeOn', function () {
 
   scope
     .$toObservable('testProperty')
-    .throttle(500)
+    .debounce(500)
     .tap(function () { scope.testProperty = 2; })
     .observeOn(new Rx.ScopeScheduler(scope))
     .subscribe(function () {


### PR DESCRIPTION
RxJS 3.1.2 chanaged the behavior of `.throttle()` such that it is no longer a deprecated synonym for `.debounce()`. Several tests call `.throttle()`, and the new behavior makes them fail. Changing them all to `.debounce()` fixes.