### PR TITLE
fix safeApply when scope is destroyed

### DIFF
--- a/dist/rx.angular.js
+++ b/dist/rx.angular.js
@@ -203,10 +203,14 @@ function thrower(e) {
   Rx.Observable.prototype.safeApply = function($scope, fn){
     fn = angular.isFunction(fn) ? fn : noop;
 
-    return this.tap(function (data) {
-      ($scope.$$phase || $scope.$root.$$phase) ?
-        fn(data) :
-        $scope.$apply(function () { fn(data); });
+    return this
+      .takeWhile(function () {
+        return !$scope.$$destroyed;
+      })
+      .tap(function (data) {
+        ($scope.$$phase || $scope.$root.$$phase) ?
+          fn(data) :
+          $scope.$apply(function () { fn(data); });
     });
   };
 

--- a/src/safeApply.js
+++ b/src/safeApply.js
@@ -3,9 +3,13 @@
   Rx.Observable.prototype.safeApply = function($scope, fn){
     fn = angular.isFunction(fn) ? fn : noop;
 
-    return this.tap(function (data) {
-      ($scope.$$phase || $scope.$root.$$phase) ?
-        fn(data) :
-        $scope.$apply(function () { fn(data); });
+    return this
+      .takeWhile(function () {
+        return !$scope.$$destroyed;
+      })
+      .tap(function (data) {
+        ($scope.$$phase || $scope.$root.$$phase) ?
+          fn(data) :
+          $scope.$apply(function () { fn(data); });
     });
   };


### PR DESCRIPTION
When $scope is destroyed, its $root sets to null and safeApply throws
`Uncaught TypeError: Cannot read property '$$phase' of undefined.`

My proposition is to dispose safeApply observable when $scope is '$$destroyed' as there is no much sense in updating destroyed scope