### PR TITLE
Fix rx.js versions in the examples

### DIFF
--- a/examples/$createObservableFunction/index.html
+++ b/examples/$createObservableFunction/index.html
@@ -21,7 +21,7 @@
       </li>
     </ul>
 
-    <script src="http://cdnjs.cloudflare.com/ajax/libs/rxjs/2.2.27/rx.lite.compat.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/rxjs/4.0.7/rx.lite.compat.js"></script>
     <script src="http://ajax.googleapis.com/ajax/libs/angularjs/1.2.19/angular.min.js"></script>
     <script src="../../dist/rx.angular.js"></script>
     <script src="app.js"></script>

--- a/examples/$createObservableFunctionAsController/index.html
+++ b/examples/$createObservableFunctionAsController/index.html
@@ -21,7 +21,7 @@
       </li>
     </ul>
 
-    <script src="http://cdnjs.cloudflare.com/ajax/libs/rxjs/2.2.27/rx.lite.compat.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/rxjs/4.0.7/rx.lite.compat.js"></script>
     <script src="http://ajax.googleapis.com/ajax/libs/angularjs/1.3.15/angular.min.js"></script>
     <script src="../../dist/rx.angular.js"></script>
     <script src="app.js"></script>

--- a/examples/$toObservable/index.html
+++ b/examples/$toObservable/index.html
@@ -19,7 +19,7 @@
       </li>
     </ul>
 
-    <script src="http://cdnjs.cloudflare.com/ajax/libs/rxjs/2.2.27/rx.lite.compat.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/rxjs/4.0.7/rx.lite.compat.js"></script>
     <script src="http://ajax.googleapis.com/ajax/libs/angularjs/1.2.19/angular.min.js"></script>
     <script src="../../dist/rx.angular.js"></script>
     <script src="app.js"></script>

--- a/examples/canvaspaint/index.html
+++ b/examples/canvaspaint/index.html
@@ -21,7 +21,7 @@
         </div>
     </div>
     <script src="http://ajax.googleapis.com/ajax/libs/angularjs/1.2.19/angular.js"></script>
-    <script src="http://cdn.jsdelivr.net/rxjs/2.2.27/rx.all.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/rxjs/4.0.7/rx.all.js"></script>
 
     <script src="../../dist/rx.angular.js"></script>
     <script src="app.js"></script>

--- a/examples/draganddrop/index.html
+++ b/examples/draganddrop/index.html
@@ -19,7 +19,7 @@
 		</div>
 	</div>
 	<script src="http://ajax.googleapis.com/ajax/libs/angularjs/1.2.19/angular.js"></script>
-	<script src="http://cdn.jsdelivr.net/rxjs/2.2.27/rx.all.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/rxjs/4.0.7/rx.all.js"></script>
 
 	<script src="../../dist/rx.angular.js"></script>
 	<script src="app.js"></script>

--- a/examples/konamicode/index.html
+++ b/examples/konamicode/index.html
@@ -27,7 +27,7 @@
     </div>
     <!-- make sure you include angular before Rx -->
     <script src="http://ajax.googleapis.com/ajax/libs/angularjs/1.2.19/angular.js"></script>
-    <script src="http://cdnjs.cloudflare.com/ajax/libs/rxjs/2.2.27/rx.all.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/rxjs/4.0.7/rx.all.js"></script>
     <script src="../../dist/rx.angular.js"></script>
     <script src="app.js"></script>
 </body>

--- a/examples/observeonscope/observeonscope.html
+++ b/examples/observeonscope/observeonscope.html
@@ -16,7 +16,7 @@
     </ul>
 
     <input type="text" ng-model="name" />
-    <script src="http://cdnjs.cloudflare.com/ajax/libs/rxjs/2.2.27/rx.lite.compat.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/rxjs/4.0.7/rx.lite.compat.js"></script>
     <script src="http://ajax.googleapis.com/ajax/libs/angularjs/1.2.19/angular.min.js"></script>
     <script src="../../dist/rx.angular.js"></script>
     <script src="app.js"></script>

--- a/examples/timeflies/index.html
+++ b/examples/timeflies/index.html
@@ -1,4 +1,4 @@
-﻿<!DOCTYPE html>
+<!DOCTYPE html>
 <html>
 <head>
     <meta http-equiv="X-UA-Compatible" content="IE=edge" >
@@ -19,7 +19,7 @@
         </div>
     </div>
     <script src="http://ajax.googleapis.com/ajax/libs/angularjs/1.2.19/angular.js"></script>
-    <script src="http://cdnjs.cloudflare.com/ajax/libs/rxjs/2.2.27/rx.all.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/rxjs/4.0.7/rx.all.js"></script>
     <script src="../../dist/rx.angular.js"></script>
     <script src="app.js"></script>
 </body>


### PR DESCRIPTION
Currently examples are not working with the rx.js versions that are set
in html files. Upgrading them to newer version fixes the problem #120.