### PR TITLE
Fix 'ReferenceError: isFunction is not defined'

### DIFF
--- a/src/internal/trycatch.js
+++ b/src/internal/trycatch.js
@@ -12,7 +12,7 @@ function tryCatcherGen(tryCatchTarget) {
 }
 
 function tryCatch(fn) {
-  if (!isFunction(fn)) { throw new TypeError('fn must be a function'); }
+  if (!angular.isFunction(fn)) { throw new TypeError('fn must be a function'); }
   return tryCatcherGen(fn);
 }
 


### PR DESCRIPTION
When adding a listener to `$createObservableFunction` I got this error. I assume this code is meant to call `angular.isFunction` as `isFunction` is nowhere to be found :-)