### PR TITLE
Update grunt-ng-annotate to fix peerDependency problems. Fixes #143

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "grunt-contrib-jshint": "*",
     "grunt-contrib-qunit": "*",
     "grunt-contrib-uglify": "*",
-    "grunt-ng-annotate": "^0.10.0",
+    "grunt-ng-annotate": "^2.0.2",
     "load-grunt-tasks": "*"
   },
   "jam": {


### PR DESCRIPTION
Should fix Travis build failing on `npm install`.
