### PR TITLE
Don't run $apply if the scope was destroyed

### DIFF
--- a/src/safeApply.js
+++ b/src/safeApply.js
@@ -21,7 +21,7 @@
             $scope.$apply(function () { onError(error); });
         },
         function (){
-          ($scope.$$phase || $scope.$root.$$phase) ?
+          ($scope.$$destroyed || $scope.$$phase || $scope.$root.$$phase) ?
             onComplete() :
             $scope.$apply(function () { onComplete(); });
         });


### PR DESCRIPTION
This can happen when the "stream" that triggers safeApply was completed after the scope was destroyed (e.g. the angular app was destroyed, which happens during jasmine unit tests)

Maybe we could also put a $destroy event listener to stop this observable as soon as it happens.

Right now, without this change, I would get an error like "TypeError: Cannot read property '$$phase' of null" when the angular app is already destroyed.
