### PR TITLE
npm for rx-lite is  incorrect

### DIFF
--- a/modules/rx.lite.angular/readme.md
+++ b/modules/rx.lite.angular/readme.md
@@ -111,8 +111,8 @@ $ cd rx.angular.js/modules/rx.lite.angular
 ```
 ### Installing with [NPM](https://npmjs.org/)
 ```bash
-npm install rx-angular-lite
-npm install -g rx-angular-lite
+npm install rx-lite-angular
+npm install -g rx-lite-angular
 ```
 
 ## License ##


### PR DESCRIPTION
There is an error in the NPM package name ,
as written on NPM registry it should be `npm install rx-lite-angular`
and not `rx-angular-lite` as written at the docs.
see
https://www.npmjs.com/package/rx-lite-angular